### PR TITLE
Feature/byte representation

### DIFF
--- a/questionpy_common/constants.py
+++ b/questionpy_common/constants.py
@@ -1,5 +1,7 @@
 from typing import Final
 
+from questionpy_common.misc import Bytes, ByteSize
+
 # Request.
-MAX_BYTES_PACKAGE: Final[int] = 20_971_520
-MAX_BYTES_QUESTION_STATE: Final[int] = 2_097_152
+MAX_BYTES_PACKAGE: Final[Bytes] = Bytes(20, ByteSize.MiB)
+MAX_BYTES_QUESTION_STATE: Final[Bytes] = Bytes(2, ByteSize.MiB)

--- a/questionpy_common/misc.py
+++ b/questionpy_common/misc.py
@@ -1,0 +1,101 @@
+from enum import IntEnum
+from typing import overload, Union, Optional
+
+
+class ByteSize(IntEnum):
+    # pylint: disable=invalid-name
+    B = 1
+    KiB = 1024
+    MiB = 1024 * KiB
+    GiB = 1024 * MiB
+    TiB = 1024 * GiB
+
+
+class Bytes(int):
+    """Bytes class for easier byte representation."""
+
+    @overload
+    def __new__(cls, value: int, unit: ByteSize = ByteSize.B) -> 'Bytes':
+        ...
+
+    @overload
+    def __new__(cls, value: float, unit: ByteSize = ByteSize.B) -> 'Bytes':
+        ...
+
+    @overload
+    def __new__(cls, value: str, unit: ByteSize = ByteSize.B) -> 'Bytes':
+        ...
+
+    def __new__(cls, value: Union[int, float, str], unit: ByteSize = ByteSize.B) -> 'Bytes':
+        cls._string: Optional[str] = None
+        if isinstance(value, int):
+            return super().__new__(cls, value * unit)
+        if isinstance(value, float):
+            return super().__new__(cls, round(value * unit.value))
+        if isinstance(value, str):
+            return super().__new__(cls, round(float(value) * unit.value))
+        raise TypeError(f"Cannot convert {type(value)} to Bytes.")
+
+    def convert_to(self, unit: ByteSize) -> float:
+        """
+        Convert to given unit.
+
+        :param unit: Unit to convert to.
+        :return: Converted value.
+        """
+
+        return self / unit
+
+    @staticmethod
+    def from_str(string: str) -> 'Bytes':
+        """
+        Convert a string to a Bytes object.
+
+        :param string: String to convert.
+        :return: Bytes object.
+        """
+
+        # Remove whitespace and lowercase the string
+        sanitized = string.rstrip().lower()
+
+        # Remove the unit from the string
+        if sanitized.endswith('ib'):
+            sanitized = sanitized[:-2]
+        if sanitized.endswith('b'):
+            sanitized = sanitized[:-1]
+
+        # Check binary prefix and return the correct value
+        try:
+            if sanitized.endswith('k'):
+                return Bytes(sanitized[:-1], ByteSize.KiB)
+            if sanitized.endswith('m'):
+                return Bytes(sanitized[:-1], ByteSize.MiB)
+            if sanitized.endswith('g'):
+                return Bytes(sanitized[:-1], ByteSize.GiB)
+            if sanitized.endswith('t'):
+                return Bytes(sanitized[:-1], ByteSize.TiB)
+            return Bytes(sanitized)
+        except ValueError as e:
+            raise ValueError(f"Could not convert '{string}' to Bytes.") from e
+
+    def __str__(self) -> str:
+        if self._string:
+            return self._string
+
+        absolut = abs(self)
+
+        if absolut < ByteSize.KiB:
+            self._string = f'{int(self)} {ByteSize.B.name}'
+        elif absolut < ByteSize.MiB:
+            self._string = f'{self.convert_to(ByteSize.KiB):.2f} {ByteSize.KiB.name}'
+        elif absolut < ByteSize.GiB:
+            self._string = f'{self.convert_to(ByteSize.MiB):.2f} {ByteSize.MiB.name}'
+        elif absolut < ByteSize.TiB:
+            self._string = f'{self.convert_to(ByteSize.GiB):.2f} {ByteSize.GiB.name}'
+        else:
+            self._string = f'{self.convert_to(ByteSize.TiB):.2f} {ByteSize.TiB.name}'
+
+        return self._string
+
+    def __repr__(self) -> str:
+        return f'Bytes({self})'

--- a/questionpy_common/misc.py
+++ b/questionpy_common/misc.py
@@ -36,18 +36,8 @@ class Bytes(int):
             return super().__new__(cls, round(float(value) * unit.value))
         raise TypeError(f"Cannot convert {type(value)} to Bytes.")
 
-    def convert_to(self, unit: ByteSize) -> float:
-        """
-        Convert to given unit.
-
-        :param unit: Unit to convert to.
-        :return: Converted value.
-        """
-
-        return self / unit
-
-    @staticmethod
-    def from_str(string: str) -> 'Bytes':
+    @classmethod
+    def from_string(cls, string: str) -> 'Bytes':
         """
         Convert a string to a Bytes object.
 
@@ -67,16 +57,26 @@ class Bytes(int):
         # Check binary prefix and return the correct value
         try:
             if sanitized.endswith('k'):
-                return Bytes(sanitized[:-1], ByteSize.KiB)
+                return cls(sanitized[:-1], ByteSize.KiB)
             if sanitized.endswith('m'):
-                return Bytes(sanitized[:-1], ByteSize.MiB)
+                return cls(sanitized[:-1], ByteSize.MiB)
             if sanitized.endswith('g'):
-                return Bytes(sanitized[:-1], ByteSize.GiB)
+                return cls(sanitized[:-1], ByteSize.GiB)
             if sanitized.endswith('t'):
-                return Bytes(sanitized[:-1], ByteSize.TiB)
-            return Bytes(sanitized)
+                return cls(sanitized[:-1], ByteSize.TiB)
+            return cls(sanitized)
         except ValueError as e:
-            raise ValueError(f"Could not convert '{string}' to Bytes.") from e
+            raise ValueError(f"Could not convert '{string}'") from e
+
+    def convert_to(self, unit: ByteSize) -> float:
+        """
+        Convert to given unit.
+
+        :param unit: Unit to convert to.
+        :return: Converted value.
+        """
+
+        return self / unit
 
     def __str__(self) -> str:
         if self._string:

--- a/tests/misc_test.py
+++ b/tests/misc_test.py
@@ -5,12 +5,18 @@ import pytest
 from questionpy_common.misc import Bytes, ByteSize
 
 
+KB = 1024
+MB = 1024**2
+GB = 1024**3
+TB = 1024**4
+
+
 @pytest.mark.parametrize('byte_size, expected', [
     (ByteSize.B, 1),
-    (ByteSize.KiB, 1024),
-    (ByteSize.MiB, 1048576),
-    (ByteSize.GiB, 1073741824),
-    (ByteSize.TiB, 1099511627776),
+    (ByteSize.KiB, KB),
+    (ByteSize.MiB, MB),
+    (ByteSize.GiB, GB),
+    (ByteSize.TiB, TB),
 ])
 def test_byte_size(byte_size: ByteSize, expected: int) -> None:
     assert byte_size == expected
@@ -19,12 +25,12 @@ def test_byte_size(byte_size: ByteSize, expected: int) -> None:
 @pytest.mark.parametrize('value, unit, expected', [
     # Integers.
     (1, ByteSize.B, 1),
-    (1024, ByteSize.B, 1024),
-    (1, ByteSize.KiB, 1024),
-    (1, ByteSize.MiB, 1048576),
-    (1, ByteSize.GiB, 1073741824),
-    (1, ByteSize.TiB, 1099511627776),
-    (-1, ByteSize.KiB, -1024),
+    (1024, ByteSize.B, KB),
+    (1, ByteSize.KiB, KB),
+    (1, ByteSize.MiB, MB),
+    (1, ByteSize.GiB, GB),
+    (1, ByteSize.TiB, TB),
+    (-1, ByteSize.KiB, -KB),
 
     # Floats.
     (0.4, ByteSize.B, 0),
@@ -40,31 +46,44 @@ def test_byte_size(byte_size: ByteSize, expected: int) -> None:
     ('0.4', ByteSize.B, 0),
     ('0.6', ByteSize.B, 1),
     ('1.5', ByteSize.KiB, 1536),
-    ('1', ByteSize.MiB, 1048576),
-    ('1', ByteSize.GiB, 1073741824),
-    ('1', ByteSize.TiB, 1099511627776),
+    ('1', ByteSize.MiB, MB),
+    ('1', ByteSize.GiB, GB),
+    ('1', ByteSize.TiB, TB),
 
     ('+0.4', ByteSize.B, 0),
     ('+0.6', ByteSize.B, 1),
     ('+1.5', ByteSize.KiB, 1536),
-    ('+1', ByteSize.MiB, 1048576),
-    ('+1', ByteSize.GiB, 1073741824),
-    ('+1', ByteSize.TiB, 1099511627776),
+    ('+1', ByteSize.MiB, MB),
+    ('+1', ByteSize.GiB, GB),
+    ('+1', ByteSize.TiB, TB),
 
     ('-0.4', ByteSize.B, 0),
     ('-0.6', ByteSize.B, -1),
     ('-1.5', ByteSize.KiB, -1536),
-    ('-1', ByteSize.MiB, -1048576),
-    ('-1', ByteSize.GiB, -1073741824),
-    ('-1', ByteSize.TiB, -1099511627776),
+    ('-1', ByteSize.MiB, -MB),
+    ('-1', ByteSize.GiB, -GB),
+    ('-1', ByteSize.TiB, -TB),
 ])
 def test_init(value: float, unit: ByteSize, expected: int) -> None:
     assert Bytes(value, unit) == expected
 
 
-def test_zero() -> None:
-    assert 0 == Bytes(0) == Bytes(-0) == Bytes(0.0) == Bytes(-0.0) == Bytes('0') == Bytes('-0') == Bytes('+0') == \
-           Bytes('0.0') == Bytes('-0.0') == Bytes('+0.0')
+@pytest.mark.parametrize('value', [
+    Bytes(0),
+    Bytes(-0),
+    Bytes(+0),
+    Bytes(0.0),
+    Bytes(-0.0),
+    Bytes(+0.0),
+    Bytes('0'),
+    Bytes('-0'),
+    Bytes('+0'),
+    Bytes('0.0'),
+    Bytes('-0.0'),
+    Bytes('+0.0')
+])
+def test_zero(value: Bytes) -> None:
+    assert 0 == value
 
 
 def test_incorrect_type() -> None:
@@ -99,29 +118,29 @@ def test_incorrect_input(value: str) -> None:
     ('1.0', 1),
     ('1.4', 1),
     ('1.6', 2),
-    ('1024', 1024),
-    ('1024.0', 1024),
-    ('1024.5', 1024),
-    ('1024.6', 1025),
+    ('1024', KB),
+    ('1024.0', KB),
+    ('1024.5', KB),
+    ('1024.6', KB + 1),
 
     # With unit.
     ('1 b', 1),
     ('1 B', 1),
-    ('1k', 1024),
-    ('1kb', 1024),
-    ('1KB', 1024),
-    ('1kib', 1024),
-    ('1 m', 1048576),
-    ('1 mb', 1048576),
-    ('1 MB', 1048576),
-    ('1 mib', 1048576),
-    ('1 G', 1073741824),
-    ('1 Gb', 1073741824),
-    ('1 gB', 1073741824),
-    ('1 giB', 1073741824),
-    ('1 T  ', 1099511627776),
-    ('  1 tib', 1099511627776),
-    ('  1 TiB  ', 1099511627776),
+    ('1k', KB),
+    ('1kb', KB),
+    ('1KB', KB),
+    ('1kib', KB),
+    ('1 m', MB),
+    ('1 mb', MB),
+    ('1 MB', MB),
+    ('1 mib', MB),
+    ('1 G', GB),
+    ('1 Gb', GB),
+    ('1 gB', GB),
+    ('1 giB', GB),
+    ('1 T  ', TB),
+    ('  1 tib', TB),
+    ('  1 TiB  ', TB),
 ])
 def test_from_string(string: str, expected: int) -> None:
     assert Bytes.from_str(string) == expected
@@ -144,25 +163,25 @@ def test_from_string_not_valid(string: str) -> None:
     (Bytes(0), ByteSize.B, 0),
     (Bytes(-1), ByteSize.B, -1),
 
-    (Bytes(1024), ByteSize.KiB, 1),
-    (Bytes(1, ByteSize.KiB), ByteSize.B, 1024),
+    (Bytes(KB), ByteSize.KiB, 1),
+    (Bytes(1, ByteSize.KiB), ByteSize.B, KB),
 
-    (Bytes(1024, ByteSize.MiB), ByteSize.GiB, 1),
-    (Bytes(1, ByteSize.GiB), ByteSize.MiB, 1024),
+    (Bytes(KB, ByteSize.MiB), ByteSize.GiB, 1),
+    (Bytes(1, ByteSize.GiB), ByteSize.MiB, KB),
 
-    (Bytes(1024, ByteSize.MiB), ByteSize.GiB, 1),
-    (Bytes(1, ByteSize.GiB), ByteSize.MiB, 1024),
+    (Bytes(KB, ByteSize.MiB), ByteSize.GiB, 1),
+    (Bytes(1, ByteSize.GiB), ByteSize.MiB, KB),
 
-    (Bytes(1024, ByteSize.GiB), ByteSize.TiB, 1),
-    (Bytes(1, ByteSize.TiB), ByteSize.GiB, 1024),
+    (Bytes(KB, ByteSize.GiB), ByteSize.TiB, 1),
+    (Bytes(1, ByteSize.TiB), ByteSize.GiB, KB),
 
-    (Bytes(1024, ByteSize.TiB), ByteSize.GiB, 1024),
+    (Bytes(KB, ByteSize.TiB), ByteSize.GiB, KB),
 
     (Bytes(1536, ByteSize.KiB), ByteSize.GiB, 1.5),
     (Bytes(-1.5, ByteSize.GiB), ByteSize.KiB, -1536),
 
-    (Bytes(2, ByteSize.MiB), ByteSize.B, 2097152),
-    (Bytes(-2, ByteSize.GiB), ByteSize.B, -2147483648),
+    (Bytes(2, ByteSize.MiB), ByteSize.B, 2*MB),
+    (Bytes(-2, ByteSize.GiB), ByteSize.B, -2*MB),
 ])
 def test_convert_to(value: Bytes, unit: ByteSize, expected: int) -> None:
     pytest.approx(value.convert_to(unit), expected)
@@ -170,11 +189,11 @@ def test_convert_to(value: Bytes, unit: ByteSize, expected: int) -> None:
 
 @pytest.mark.parametrize('value, expected', [
     (Bytes(1), '1 B'),
-    (Bytes(1024), '1.00 KiB'),
-    (Bytes(1024, ByteSize.KiB), '1.00 MiB'),
-    (Bytes(1024, ByteSize.MiB), '1.00 GiB'),
-    (Bytes(1024, ByteSize.GiB), '1.00 TiB'),
-    (Bytes(1024, ByteSize.TiB), '1024.00 TiB'),
+    (Bytes(KB), '1.00 KiB'),
+    (Bytes(KB, ByteSize.KiB), '1.00 MiB'),
+    (Bytes(KB, ByteSize.MiB), '1.00 GiB'),
+    (Bytes(KB, ByteSize.GiB), '1.00 TiB'),
+    (Bytes(KB, ByteSize.TiB), '1024.00 TiB'),
 
     (Bytes(1.5), '2 B'),
     (Bytes(1536), '1.50 KiB'),

--- a/tests/misc_test.py
+++ b/tests/misc_test.py
@@ -196,5 +196,5 @@ def test_to_str(value: Bytes, expected: str) -> None:
 
 def test_repr() -> None:
     with patch.object(Bytes, '__str__', return_value='test') as mock:
-        assert repr(Bytes(1)) == "Bytes(test)"
+        assert repr(Bytes(1)) == 'Bytes(test)'
         mock.assert_called_once_with()

--- a/tests/misc_test.py
+++ b/tests/misc_test.py
@@ -143,7 +143,7 @@ def test_incorrect_input(value: str) -> None:
     ('  1 TiB  ', TB),
 ])
 def test_from_string(string: str, expected: int) -> None:
-    assert Bytes.from_str(string) == expected
+    assert Bytes.from_string(string) == expected
 
 
 @pytest.mark.parametrize('string', [
@@ -155,7 +155,7 @@ def test_from_string(string: str, expected: int) -> None:
 ])
 def test_from_string_not_valid(string: str) -> None:
     with pytest.raises(ValueError):
-        Bytes.from_str(string)
+        Bytes.from_string(string)
 
 
 @pytest.mark.parametrize('value, unit, expected', [
@@ -180,8 +180,8 @@ def test_from_string_not_valid(string: str) -> None:
     (Bytes(1536, ByteSize.KiB), ByteSize.GiB, 1.5),
     (Bytes(-1.5, ByteSize.GiB), ByteSize.KiB, -1536),
 
-    (Bytes(2, ByteSize.MiB), ByteSize.B, 2*MB),
-    (Bytes(-2, ByteSize.GiB), ByteSize.B, -2*MB),
+    (Bytes(2, ByteSize.MiB), ByteSize.B, 2 * MB),
+    (Bytes(-2, ByteSize.GiB), ByteSize.B, -2 * MB),
 ])
 def test_convert_to(value: Bytes, unit: ByteSize, expected: int) -> None:
     pytest.approx(value.convert_to(unit), expected)

--- a/tests/misc_test.py
+++ b/tests/misc_test.py
@@ -1,0 +1,200 @@
+from unittest.mock import patch
+
+import pytest
+
+from questionpy_common.misc import Bytes, ByteSize
+
+
+@pytest.mark.parametrize('byte_size, expected', [
+    (ByteSize.B, 1),
+    (ByteSize.KiB, 1024),
+    (ByteSize.MiB, 1048576),
+    (ByteSize.GiB, 1073741824),
+    (ByteSize.TiB, 1099511627776),
+])
+def test_byte_size(byte_size: ByteSize, expected: int) -> None:
+    assert byte_size == expected
+
+
+@pytest.mark.parametrize('value, unit, expected', [
+    # Integers.
+    (1, ByteSize.B, 1),
+    (1024, ByteSize.B, 1024),
+    (1, ByteSize.KiB, 1024),
+    (1, ByteSize.MiB, 1048576),
+    (1, ByteSize.GiB, 1073741824),
+    (1, ByteSize.TiB, 1099511627776),
+    (-1, ByteSize.KiB, -1024),
+
+    # Floats.
+    (0.4, ByteSize.B, 0),
+    (0.6, ByteSize.B, 1),
+    (1.0, ByteSize.B, 1),
+    (0.5, ByteSize.KiB, 512),
+
+    (-0.4, ByteSize.B, 0),
+    (-0.6, ByteSize.B, -1),
+    (-0.5, ByteSize.KiB, -512),
+
+    # Strings.
+    ('0.4', ByteSize.B, 0),
+    ('0.6', ByteSize.B, 1),
+    ('1.5', ByteSize.KiB, 1536),
+    ('1', ByteSize.MiB, 1048576),
+    ('1', ByteSize.GiB, 1073741824),
+    ('1', ByteSize.TiB, 1099511627776),
+
+    ('+0.4', ByteSize.B, 0),
+    ('+0.6', ByteSize.B, 1),
+    ('+1.5', ByteSize.KiB, 1536),
+    ('+1', ByteSize.MiB, 1048576),
+    ('+1', ByteSize.GiB, 1073741824),
+    ('+1', ByteSize.TiB, 1099511627776),
+
+    ('-0.4', ByteSize.B, 0),
+    ('-0.6', ByteSize.B, -1),
+    ('-1.5', ByteSize.KiB, -1536),
+    ('-1', ByteSize.MiB, -1048576),
+    ('-1', ByteSize.GiB, -1073741824),
+    ('-1', ByteSize.TiB, -1099511627776),
+])
+def test_init(value: float, unit: ByteSize, expected: int) -> None:
+    assert Bytes(value, unit) == expected
+
+
+def test_zero() -> None:
+    assert 0 == Bytes(0) == Bytes(-0) == Bytes(0.0) == Bytes(-0.0) == Bytes('0') == Bytes('-0') == Bytes('+0') == \
+           Bytes('0.0') == Bytes('-0.0') == Bytes('+0.0')
+
+
+def test_incorrect_type() -> None:
+    with pytest.raises(TypeError):
+        Bytes([])  # type: ignore
+
+
+@pytest.mark.parametrize('value', [
+    '10,0',
+    '1 00'
+    '--1',
+    '++1',
+    '1-1',
+    '1.0.0',
+    'abc',
+    '100abc',
+    'abc100',
+    'abc100abc',
+    '100 abc',
+    'abc 100',
+    'abc 100 abc',
+])
+def test_incorrect_input(value: str) -> None:
+    with pytest.raises(ValueError):
+        Bytes(value)
+
+
+@pytest.mark.parametrize('string, expected', [
+    # Without unit.
+    ('0', 0),
+    ('1', 1),
+    ('1.0', 1),
+    ('1.4', 1),
+    ('1.6', 2),
+    ('1024', 1024),
+    ('1024.0', 1024),
+    ('1024.5', 1024),
+    ('1024.6', 1025),
+
+    # With unit.
+    ('1 b', 1),
+    ('1 B', 1),
+    ('1k', 1024),
+    ('1kb', 1024),
+    ('1KB', 1024),
+    ('1kib', 1024),
+    ('1 m', 1048576),
+    ('1 mb', 1048576),
+    ('1 MB', 1048576),
+    ('1 mib', 1048576),
+    ('1 G', 1073741824),
+    ('1 Gb', 1073741824),
+    ('1 gB', 1073741824),
+    ('1 giB', 1073741824),
+    ('1 T  ', 1099511627776),
+    ('  1 tib', 1099511627776),
+    ('  1 TiB  ', 1099511627776),
+])
+def test_from_string(string: str, expected: int) -> None:
+    assert Bytes.from_str(string) == expected
+
+
+@pytest.mark.parametrize('string', [
+    '1.0.0',
+    'KiB',
+    '1 KiB KiB',
+    '1 5',
+    '1 5 MiB',
+])
+def test_from_string_not_valid(string: str) -> None:
+    with pytest.raises(ValueError):
+        Bytes.from_str(string)
+
+
+@pytest.mark.parametrize('value, unit, expected', [
+    (Bytes(1), ByteSize.B, 1),
+    (Bytes(0), ByteSize.B, 0),
+    (Bytes(-1), ByteSize.B, -1),
+
+    (Bytes(1024), ByteSize.KiB, 1),
+    (Bytes(1, ByteSize.KiB), ByteSize.B, 1024),
+
+    (Bytes(1024, ByteSize.MiB), ByteSize.GiB, 1),
+    (Bytes(1, ByteSize.GiB), ByteSize.MiB, 1024),
+
+    (Bytes(1024, ByteSize.MiB), ByteSize.GiB, 1),
+    (Bytes(1, ByteSize.GiB), ByteSize.MiB, 1024),
+
+    (Bytes(1024, ByteSize.GiB), ByteSize.TiB, 1),
+    (Bytes(1, ByteSize.TiB), ByteSize.GiB, 1024),
+
+    (Bytes(1024, ByteSize.TiB), ByteSize.GiB, 1024),
+
+    (Bytes(1536, ByteSize.KiB), ByteSize.GiB, 1.5),
+    (Bytes(-1.5, ByteSize.GiB), ByteSize.KiB, -1536),
+
+    (Bytes(2, ByteSize.MiB), ByteSize.B, 2097152),
+    (Bytes(-2, ByteSize.GiB), ByteSize.B, -2147483648),
+])
+def test_convert_to(value: Bytes, unit: ByteSize, expected: int) -> None:
+    pytest.approx(value.convert_to(unit), expected)
+
+
+@pytest.mark.parametrize('value, expected', [
+    (Bytes(1), '1 B'),
+    (Bytes(1024), '1.00 KiB'),
+    (Bytes(1024, ByteSize.KiB), '1.00 MiB'),
+    (Bytes(1024, ByteSize.MiB), '1.00 GiB'),
+    (Bytes(1024, ByteSize.GiB), '1.00 TiB'),
+    (Bytes(1024, ByteSize.TiB), '1024.00 TiB'),
+
+    (Bytes(1.5), '2 B'),
+    (Bytes(1536), '1.50 KiB'),
+    (Bytes(1536, ByteSize.KiB), '1.50 MiB'),
+    (Bytes(1536, ByteSize.MiB), '1.50 GiB'),
+    (Bytes(1536, ByteSize.GiB), '1.50 TiB'),
+    (Bytes(1536, ByteSize.TiB), '1536.00 TiB'),
+
+    (Bytes(-1.5), '-2 B'),
+    (Bytes(-1536), '-1.50 KiB'),
+    (Bytes(-1536, ByteSize.KiB), '-1.50 MiB'),
+    (Bytes(-1536, ByteSize.MiB), '-1.50 GiB'),
+    (Bytes(-1536, ByteSize.GiB), '-1.50 TiB'),
+    (Bytes(-1536, ByteSize.TiB), '-1536.00 TiB')
+])
+def test_to_str(value: Bytes, expected: str) -> None:
+    assert str(value) == expected
+
+
+def test_repr() -> None:
+    with patch.object(Bytes, '__str__', return_value='test') as mock:
+        assert repr(Bytes(1)) == "Bytes(test)"
+        mock.assert_called_once_with()


### PR DESCRIPTION
Die `Bytes`-Klasse vereinfacht das Arbeiten mit Bytes.

Mit der Methode `from_string()` kann ein String eingelesen werden und direkt in Bytes umgewandelt werden, dabei wird auch die Einheit (z.B. MB, GiB, tb) berücksichtigt. Diese Funktion kann beim Parsen der `config.ini` des [Servers](https://github.com/questionpy-org/questionpy-server) verwendet werden.
Die Methode `convert_to()` ermöglicht es mithilfe des Enums `ByteSize` zwischen den verschiedenen Einheiten zu konvertieren.
Wendet man `str()` auf ein `Bytes`-Objekt an, wird eine menschenfreundliche Repräsentation der Bytes zurückgegeben (z.B.: 1.50 KiB, statt 1536). 