### PR TITLE
feat: add support for namespaces

### DIFF
--- a/questionpy_common/manifest.py
+++ b/questionpy_common/manifest.py
@@ -1,7 +1,11 @@
 from enum import Enum
-from typing import Optional, Union
+from keyword import iskeyword, issoftkeyword
+from typing import Optional, Union, Annotated
+from urllib.parse import quote
 
 from pydantic import BaseModel
+from pydantic.class_validators import validator
+from pydantic.fields import Field
 
 
 class PackageType(str, Enum):
@@ -10,19 +14,65 @@ class PackageType(str, Enum):
     QUESTION = 'QUESTION'
 
 
+# Defaults.
+DEFAULT_ENTRYPOINT = '__main__'
+DEFAULT_NAMESPACE = 'default'
+DEFAULT_PACKAGETYPE = PackageType.QUESTIONTYPE
+
+# Regular expressions.
+RE_SEMVER = r'^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)' \
+            r'(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
+
+
+# Validators.
+def ensure_is_valid_name(name: str) -> str:
+    """
+    Raises ValueError if the given name does not match the following conditions:
+    It should be:
+        - a valid Python identifier
+        - NOT a Python keyword
+        - lowercase
+        - URL-friendly (i.e. only characters which will not be %-escaped)
+
+    :param name: the name to be checked
+    :return: name
+    """
+    if len(name) > 127:
+        raise ValueError("can only have at most 127 character")
+    if not name.isidentifier():
+        raise ValueError("is not valid")
+    if iskeyword(name) or issoftkeyword(name) or name in ["_", "case", "match"]:
+        raise ValueError("can not be a Python keyword")
+    if not name.islower():
+        raise ValueError("has to be lowercase")
+    if quote(name) != name:
+        raise ValueError("can only contain URL-friendly characters")
+    return name
+
+
 class Manifest(BaseModel):
     short_name: str
-    version: str
-    api_version: str
+    namespace: str = DEFAULT_NAMESPACE
+    version: Annotated[str, Field(regex=RE_SEMVER)]
+    api_version: Annotated[str, Field(regex=RE_SEMVER)]
     author: str
     name: dict[str, str] = {}
-    entrypoint: str = "__main__"
+    entrypoint: str = DEFAULT_ENTRYPOINT
     url: Optional[str] = None
     languages: set[str] = set()
     description: dict[str, str] = {}
     icon: Optional[str] = None
-    type: PackageType = PackageType.QUESTIONTYPE
+    type: PackageType = DEFAULT_PACKAGETYPE
     license: Optional[str] = None
     permissions: set[str] = set()
     tags: set[str] = set()
     requirements: Optional[Union[str, list[str]]] = None
+
+    @validator('short_name', 'namespace')
+    # pylint: disable=no-self-argument
+    def ensure_is_valid_name(cls, value: str) -> str:
+        return ensure_is_valid_name(value)
+
+    @property
+    def identifier(self) -> str:
+        return f"@{self.namespace}/{self.short_name}"

--- a/tests/manifest_test.py
+++ b/tests/manifest_test.py
@@ -50,3 +50,49 @@ def test_ignore_additional_properties(data: dict[str, Any]) -> None:
 def test_not_valid_manifest(data: dict[str, Any], error_message: str) -> None:
     with pytest.raises(ValidationError, match=error_message):
         Manifest(**data)
+
+
+@pytest.mark.parametrize('field', (
+    'short_name',
+    'namespace'
+))
+@pytest.mark.parametrize('name', (
+    'default',
+    'a_name',
+    '_name',
+    'name_',
+    '_name_',
+    '_a_name_',
+))
+def test_valid_name(field: str, name: str) -> None:
+    manifest = minimal_manifest.copy()
+    manifest[field] = name
+    Manifest(**manifest)
+
+
+@pytest.mark.parametrize('field', (
+    'short_name',
+    'namespace'
+))
+@pytest.mark.parametrize('name, error_message', (
+    ['notValid', 'has to be lowercase'],
+    ['', 'is not valid'],
+    [' not_valid', 'is not valid'],
+    ['not_valid ', 'is not valid'],
+    ['not-valid', 'is not valid'],
+    ['not~valid', 'is not valid'],
+    ['not valid', 'is not valid'],
+    ['42', 'is not valid'],
+    ['def', 'can not be a Python keyword'],
+    ['class', 'can not be a Python keyword'],
+    ['global', 'can not be a Python keyword'],
+    ['match', 'can not be a Python keyword'],
+    ['_', 'can not be a Python keyword'],
+    ['\u03c0', 'can only contain URL-friendly characters']
+))
+def test_not_valid_name(field: str, name: str, error_message: str) -> None:
+    error = f'1 validation error for Manifest\n{field}\n  {error_message}'
+    manifest = minimal_manifest.copy()
+    manifest[field] = name
+    with pytest.raises(ValidationError, match=error):
+        Manifest(**manifest)


### PR DESCRIPTION
Das Manifest besitzt nun das Attribut `namespace`. Dieses und `short_name` unterliegen folgenden Regeln:
- kürzer als 128 Zeichen
- ist ein valider Python-Identifier
- ist kein Python-Keyword
- alle Buchstaben sind Kleinbuchstaben
- beinhaltet nur URL-freundliche Zeichen ('π' ist z.B. nicht erlaubt, da es in `%CF%80` konvertiert wird)

Bei der Erstellung dieser Regeln wurde [NPM](https://github.com/npm/validate-npm-package-name) als Inspiration verwendet. 