### PR TITLE
CI: Nur tox, tox-gh-actions und converage.py installieren

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   ci:
     # https://github.com/questionpy-org/.github
-    uses: questionpy-org/.github/.github/workflows/python-ci.yml@v5
+    uses: questionpy-org/.github/.github/workflows/python-ci.yml@v6
     with:
       # GitHub workflow inputs do not support lists, so we pass JSON.
       pytest-python-versions: '["3.9", "3.10", "3.11"]'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,16 +14,18 @@ python = "^3.9"
 pydantic = "^1.9.1"
 pydantic-factories = "^1.6.2"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pylint = "^2.14.5"
 pytest = "^7.1.2"
 pytest-md = "^0.2.0"
 pylint-pytest = "^1.1.2"
 mypy = "^0.971"
 flake8 = "^5.0.4"
-coverage = { extras = ["toml"], version = "^6.5.0" }
+
+[tool.poetry.group.ci.dependencies]
 tox = "^4.2.6"
 tox-gh-actions = "^3.0.0"
+coverage = { extras = ["toml"], version = "^6.5.0" }
 
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Greift den Kommentar auf: https://github.com/questionpy-org/.github/pull/6#issuecomment-1387068748

tox, tox-gh-actions und coverage.py sind die einzigen Dependencies, die in der CI außerhalb von tox benötigt werden. Die drei liegen jetzt in ihrer eigenen Gruppe `ci`, die alleine in der CI installiert wird.

Anscheinend macht das allerdings keinen großen Performance-Unterschied, da die Dependencies eh gecached werden. Daher bin ich mir selbst nicht sicher, ob sich die Komplexität lohnt. Wie seht ihr das?