### PR TITLE
refactor: add MANIFEST_FILENAME constant

### DIFF
--- a/questionpy_common/constants.py
+++ b/questionpy_common/constants.py
@@ -14,3 +14,5 @@ MiB: Final[int] = 1024 * KiB  # pylint: disable=invalid-name
 # Request.
 MAX_PACKAGE_SIZE: Final[ByteSize] = ByteSize(20 * MiB)
 MAX_QUESTION_STATE_SIZE: Final[ByteSize] = ByteSize(2 * MiB)
+
+MANIFEST_FILENAME = "qpy_manifest.json"


### PR DESCRIPTION
Provide `MANIFEST_FILENAME` in common as it's used across packages.